### PR TITLE
Update README to reflect pyvirtualcam 0.4 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # HackWestern 7
 
 ## Installation Instructions:
-1. Download OBS Studio from https://obsproject.com/download
-2. Download OBS Virtual Camera from ...
-3. Clone repo
-4. Run `pip install -r requirements.txt` NOTE: Only supports python 3.6, 3.7 and 3.8
-5. Run `python cam.py`
-6. Restart zoom or other apps and choose OBS-Camera (NOT OBS-virtual-camera)
+1. Download and install OBS Studio from https://obsproject.com/download
+2. Clone repo
+3. Run `pip install -r requirements.txt` NOTE: Only supports python 3.6, 3.7 and 3.8
+4. Run `python cam.py`
+5. Restart zoom or other apps and choose OBS Virtual Camera
 


### PR DESCRIPTION
pyvirtualcam 0.4 uses the new built-in virtual camera of OBS now, so there is no need anymore to install a separate plugin.